### PR TITLE
move engine to an isolated namespace

### DIFF
--- a/app/controllers/revise_auth/email_controller.rb
+++ b/app/controllers/revise_auth/email_controller.rb
@@ -8,7 +8,7 @@ class ReviseAuth::EmailController < ReviseAuthController
       user_signed_in?
       redirect_to(user_signed_in? ? profile_path : root_path)
     else
-      redirect_to root_path, alert: I18n.t("revise_auth.email_confirm_failed")
+      redirect_to main_app.root_path, alert: I18n.t("revise_auth.email_confirm_failed")
     end
   end
 

--- a/app/controllers/revise_auth/registrations_controller.rb
+++ b/app/controllers/revise_auth/registrations_controller.rb
@@ -9,7 +9,7 @@ class ReviseAuth::RegistrationsController < ReviseAuthController
     @user = User.new(sign_up_params)
     if @user.save
       login(@user)
-      redirect_to root_path
+      redirect_to main_app.root_path
     else
       render :new, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class ReviseAuth::RegistrationsController < ReviseAuthController
   def destroy
     current_user.destroy
     logout
-    redirect_to root_path, status: :see_other, alert: I18n.t("revise_auth.account_deleted")
+    redirect_to main_app.root_path, status: :see_other, alert: I18n.t("revise_auth.account_deleted")
   end
 
   private

--- a/app/controllers/revise_auth/sessions_controller.rb
+++ b/app/controllers/revise_auth/sessions_controller.rb
@@ -5,7 +5,7 @@ class ReviseAuth::SessionsController < ReviseAuthController
   def create
     if (user = User.find_by(email: params[:email])&.authenticate(params[:password]))
       login(user)
-      redirect_to root_path
+      redirect_to main_app.root_path
     else
       flash[:alert] = I18n.t("revise_auth.invalid_email_or_password")
       render :new, status: :unprocessable_entity
@@ -14,6 +14,6 @@ class ReviseAuth::SessionsController < ReviseAuthController
 
   def destroy
     logout
-    redirect_to root_path
+    redirect_to main_app.root_path
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,19 @@
-Rails.application.routes.draw do
-  scope module: :revise_auth do
-    get "sign_up", to: "registrations#new"
-    post "sign_up", to: "registrations#create"
+ReviseAuth::Engine.routes.draw do
+  get "sign_up", to: "registrations#new"
+  post "sign_up", to: "registrations#create"
 
-    get "login", to: "sessions#new"
-    post "login", to: "sessions#create"
+  get "login", to: "sessions#new"
+  post "login", to: "sessions#create"
 
-    get "profile", to: "registrations#edit"
-    patch "profile", to: "registrations#update"
-    delete "profile", to: "registrations#destroy"
+  get "profile", to: "registrations#edit"
+  patch "profile", to: "registrations#update"
+  delete "profile", to: "registrations#destroy"
 
-    patch "profile/email", to: "email#update"
-    patch "profile/password", to: "password#update"
+  patch "profile/email", to: "email#update"
+  patch "profile/password", to: "password#update"
 
-    # Email confirmation
-    get "profile/email", to: "email#show"
+  # Email confirmation
+  get "profile/email", to: "email#show"
 
-    delete "logout", to: "sessions#destroy"
-  end
+  delete "logout", to: "sessions#destroy"
 end

--- a/lib/revise_auth.rb
+++ b/lib/revise_auth.rb
@@ -1,6 +1,5 @@
 require "revise_auth/version"
 require "revise_auth/engine"
-require "revise_auth/routes"
 
 module ReviseAuth
   autoload :Authentication, "revise_auth/authentication"

--- a/lib/revise_auth/authentication.rb
+++ b/lib/revise_auth/authentication.rb
@@ -22,7 +22,7 @@ module ReviseAuth
 
     # Authenticates a user or redirects to the login page
     def authenticate_user!
-      redirect_to login_path, alert: I18n.t("revise_auth.sign_up_or_login") unless user_signed_in?
+      redirect_to revise_auth.login_path, alert: I18n.t("revise_auth.sign_up_or_login") unless user_signed_in?
     end
 
     # Authenticates the current user

--- a/lib/revise_auth/engine.rb
+++ b/lib/revise_auth/engine.rb
@@ -1,5 +1,6 @@
 module ReviseAuth
   class Engine < ::Rails::Engine
+    isolate_namespace ReviseAuth
     initializer "revise_auth.controller" do
       ActiveSupport.on_load(:action_controller_base) do
         include ReviseAuth::Authentication

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -15,14 +15,14 @@
     <%= tag.p alert if alert %>
 
     <nav>
-      <%= link_to "Home", root_path %>
+      <%= link_to "Home", main_app.root_path %>
 
       <% if user_signed_in? %>
         <%= link_to "Profile", profile_path %>
-        <%= button_to "Log out", logout_path, method: :delete %>
+        <%= button_to "Log out", revise_auth.logout_path, method: :delete %>
       <% else %>
-        <%= link_to "Sign Up", sign_up_path %>
-        <%= link_to "Log in", login_path %>
+        <%= link_to "Sign Up", revise_auth.sign_up_path %>
+        <%= link_to "Log in", revise_auth.login_path %>
       <% end %>
     </nav>
 

--- a/test/dummy/app/views/main/index.html.erb
+++ b/test/dummy/app/views/main/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Revise Auth</h1>
 
 <div>
-  <%= link_to "Authentication Required", authenticated_path %>
+  <%= link_to "Authentication Required", main_app.authenticated_path %>
 </div>

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,6 +1,13 @@
 require_relative "boot"
 
-require "rails/all"
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_view/railtie"
+require "sprockets/railtie"
+require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
 
   # Store uploaded files on the local file system in a temporary directory.
-  config.active_storage.service = :test
+  # config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
 

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "main#index"
+
+  mount ReviseAuth::Engine, at: '/'
 end


### PR DESCRIPTION
This solves the problem of routes collision with the main app. For
example where there is a catch-all route like `get ':slug', to:
'pages#show'`, without the isolated namespace, the engine's routes are
appended to the main application's routes file, but they should be
prepended to work. After this change, the engine's routes can be inserted
anywhere in the main application's routes file.