### PR TITLE
Fix TypeError when no arguments are passed to model generator

### DIFF
--- a/lib/generators/revise_auth/model_generator.rb
+++ b/lib/generators/revise_auth/model_generator.rb
@@ -11,7 +11,7 @@ module ReviseAuth
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
       def initialize(args, *options)
-        @original_attributes = args[1..]
+        @original_attributes = args[1..] || []
         super
       end
 


### PR DESCRIPTION
There's an error when you try to generate model with passing any arguments

Example:

```
 rails g revise_auth:model
```

Error:

```
/Users/gathuku/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/revise_auth-9646f989725b/lib/generators/revise_auth/model_generator.rb:54:in `+': no implicit conversion of nil into Array (TypeError)
```

Fix: 

Let the `@original_attributes` variable default to `[]`  if  `nil`

