### PR TITLE
implement `generates_token_for` for email verification

### DIFF
--- a/app/controllers/revise_auth/email_controller.rb
+++ b/app/controllers/revise_auth/email_controller.rb
@@ -3,9 +3,8 @@ class ReviseAuth::EmailController < ReviseAuthController
 
   # GET /profile/email?confirmation_token=abcdef
   def show
-    if User.find_by(confirmation_token: params[:confirmation_token])&.confirm_email_change
+    if User.find_by_token_for(:email_verification, params[:confirmation_token])&.confirm_email_change
       flash[:notice] = I18n.t("revise_auth.email_confirmed")
-      user_signed_in?
       redirect_to(user_signed_in? ? profile_path : root_path)
     else
       redirect_to root_path, alert: I18n.t("revise_auth.email_confirm_failed")

--- a/app/mailers/revise_auth/mailer.rb
+++ b/app/mailers/revise_auth/mailer.rb
@@ -1,5 +1,8 @@
 class ReviseAuth::Mailer < ApplicationMailer
   def confirm_email
-    mail to: params[:user].unconfirmed_email
+    @user = params[:user]
+    @token = params[:token]
+
+    mail to: @user.unconfirmed_email
   end
 end

--- a/app/views/revise_auth/mailer/confirm_email.html.erb
+++ b/app/views/revise_auth/mailer/confirm_email.html.erb
@@ -1,7 +1,7 @@
-<p>Welcome <%= params[:user].unconfirmed_email %>!</p>
+<p>Welcome <%= @user.unconfirmed_email %>!</p>
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', profile_email_url(confirmation_token: params[:user].confirmation_token) %></p>
+<p><%= link_to "Confirm my account", profile_email_url(confirmation_token: @token) %></p>
 
 <p>This link will expire in 24 hours.</p>

--- a/lib/generators/revise_auth/model_generator.rb
+++ b/lib/generators/revise_auth/model_generator.rb
@@ -47,9 +47,7 @@ module ReviseAuth
         [
           "email:string:index",
           "password_digest:string",
-          "confirmation_token:string",
           "confirmed_at:datetime",
-          "confirmation_sent_at:datetime",
           "unconfirmed_email:string"
         ] + @original_attributes
       end

--- a/test/controllers/revise_auth/email_controller_test.rb
+++ b/test/controllers/revise_auth/email_controller_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+class ReviseAuth::EmailControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:bob)
+  end
+
+  test "changing email should send verification email" do
+    login(@user)
+
+    assert_enqueued_emails 1 do
+      assert_no_changes -> { @user.reload.email } do
+        assert_changes -> { @user.reload.unconfirmed_email } do
+          patch profile_email_url, params: {user: {unconfirmed_email: "new-email@email.com"}}
+        end
+      end
+    end
+  end
+
+  test "should verify email address" do
+    @user.update!(unconfirmed_email: "new-email@email.com")
+    token = @user.generate_token_for(:email_verification)
+
+    assert_changes -> { @user.reload.email } do
+      get profile_email_url, params: {confirmation_token: token}
+    end
+
+    assert_redirected_to root_url
+  end
+
+  test "bad token should not verify email address" do
+    @user.update!(unconfirmed_email: "new-email@email.com")
+
+    assert_no_changes -> { @user.reload.email } do
+      get profile_email_url, params: {confirmation_token: "bad"}
+    end
+
+    assert_redirected_to root_url
+  end
+
+  test "expired token should not verify email address" do
+    @user.update!(unconfirmed_email: "new-email@email.com")
+    token = @user.generate_token_for(:email_verification)
+
+    travel User::EMAIL_VERIFICATION_TOKEN_VALIDITY + 1.second
+
+    assert_no_changes -> { @user.reload.email } do
+      get profile_email_url, params: {confirmation_token: token}
+    end
+
+    assert_redirected_to root_url
+  end
+end

--- a/test/mailers/revise_auth/mailer_test.rb
+++ b/test/mailers/revise_auth/mailer_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+class ReviseAuth::MailerTest < ActionMailer::TestCase
+  test "confirm_email" do
+    user = users(:bob)
+    user.unconfirmed_email = "unconfirmed@email.com"
+    token = "s3c3tt0k3n"
+
+    email = ReviseAuth::Mailer.with(user:, token:).confirm_email
+
+    # Send the email, then test that it got queued
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ["unconfirmed@email.com"], email.to
+    assert_includes email.body.to_s, token
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,3 +12,12 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
   ActiveSupport::TestCase.fixtures :all
 end
+
+class ActiveSupport::TestCase
+  def login(user, password: "password")
+    post login_path, params: {
+      email: user.email,
+      password: password
+    }
+  end
+end


### PR DESCRIPTION
Swaps out the custom logic used to generate and store confirmation tokens with the new [Rails 7.1 `generates_token_for` API](https://github.com/rails/rails/pull/44189).

Closes #23.