### PR TITLE
Fix `revise_auth:model` generation command args

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ bundle add "revise_auth"
 
 And then execute the following to generate a `User` model (optionally adding other fields such as `first_name` and `last_name`):
 ```bash
-$ rails g revise_auth:model first_name last_name
+$ rails g revise_auth:model User first_name last_name
 $ rails db:migrate
 ```
 


### PR DESCRIPTION
When running the command that is present in the readme right now, this is the output:
```
> rails g revise_auth:model first_name last_name id_number
    generate  model
       rails  generate model first_name email:string:index password_digest:string confirmation_token:string confirmed_at:datetime confirmation_sent_at:datetime unconfirmed_email:string last_name id_number
      invoke  active_record
      create    db/migrate/20230822222738_create_first_names.rb
      create    app/models/first_name.rb
      invoke    test_unit
      create      test/models/first_name_test.rb
      create      test/fixtures/first_names.yml
      insert  app/models/first_name.rb
      insert  db/migrate/20230822222738_create_first_names.rb
🚚 Your Revise auth database model has been generated!

Next step:
  Run "rails db:migrate"
```

Generating a `FirstName` model instead of an `User` one with the added fields