### PR TITLE
Remove backport test & move authenticate_by test to user model test

### DIFF
--- a/test/models/backports_test.rb
+++ b/test/models/backports_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class BackportsTest < ActiveSupport::TestCase
-  test "authenticate_by" do
-    assert User.respond_to?(:authenticate_by)
-  end
-end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -22,4 +22,8 @@ class UserTest < ActiveSupport::TestCase
     user.valid?
     assert_equal "test@example.org", user.email
   end
+
+  test "authenticate_by" do
+    assert User.respond_to?(:authenticate_by)
+  end
 end


### PR DESCRIPTION
Since backports have been removed 80e2c07, can we remove the test file? 
I think the `authenticate_by` test still make sense, Maybe move it to `user_test` file?