### PR TITLE
remove references to `confirmation_token` in the model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-22
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
 

--- a/lib/revise_auth/model.rb
+++ b/lib/revise_auth/model.rb
@@ -7,7 +7,6 @@ module ReviseAuth
       base.const_set :PASSWORD_RESET_TOKEN_VALIDITY, 1.hour
 
       has_secure_password
-      has_secure_token :confirmation_token
 
       generates_token_for :password_reset, expires_in: base.const_get(:PASSWORD_RESET_TOKEN_VALIDITY) do
         BCrypt::Password.new(password_digest).salt[-10..]

--- a/test/dummy/db/migrate/20230112011459_create_users.rb
+++ b/test/dummy/db/migrate/20230112011459_create_users.rb
@@ -6,9 +6,7 @@ class CreateUsers < ActiveRecord::Migration[7.0]
       t.string :email
       t.string :password_digest
 
-      t.string :confirmation_token
       t.datetime :confirmed_at
-      t.datetime :confirmation_sent_at
       t.string :unconfirmed_email
 
       t.boolean :admin

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_12_011459) do
     t.string "last_name"
     t.string "email"
     t.string "password_digest"
-    t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,6 +5,14 @@ class UserTest < ActiveSupport::TestCase
     refute User.new.valid?
   end
 
+  test "can create user" do
+    password = "password123456"
+
+    assert_difference "User.count", 1, "could not create a valid user" do
+      User.create(email: "test@example.org", password: password, password_confirmation: password)
+    end
+  end
+
   test "password required" do
     user = User.new(email: "test@example.org")
     user.save


### PR DESCRIPTION
The `confirmation_token` model attribute is no longer needed now that we use `generates_token_for :email_verification`.

An addition test is also added to ensure the `User` model can be successfully created.