### PR TITLE
Fix email confirmation: ReviseAuth::Model#confirm_email_change now clears the unconfirmed email.

### DIFF
--- a/lib/revise_auth/model.rb
+++ b/lib/revise_auth/model.rb
@@ -31,7 +31,7 @@ module ReviseAuth
     end
 
     def confirm_email_change
-      update(confirmed_at: Time.current, email: unconfirmed_email)
+      update(confirmed_at: Time.current, email: unconfirmed_email, unconfirmed_email: nil)
     end
   end
 end

--- a/test/controllers/revise_auth/email_controller_test.rb
+++ b/test/controllers/revise_auth/email_controller_test.rb
@@ -22,6 +22,7 @@ class ReviseAuth::EmailControllerTest < ActionDispatch::IntegrationTest
     assert_changes -> { @user.reload.email } do
       get profile_email_url, params: {confirmation_token: token}
     end
+    assert_nil @user.reload.unconfirmed_email
     assert_redirected_to root_url
   end
 


### PR DESCRIPTION
I was trying out the gem and found out that when changing the email and confirming the view kept saying "Waiting for confirmation of...". The problem was that the unconfirmed email was never cleared when confirming it.