### PR TITLE
Refactor password reset. Make it similar to confirmation instructions.

### DIFF
--- a/app/controllers/revise_auth/password_resets_controller.rb
+++ b/app/controllers/revise_auth/password_resets_controller.rb
@@ -7,7 +7,7 @@ class ReviseAuth::PasswordResetsController < ReviseAuthController
 
   def create
     user = User.find_by(email: user_params[:email])
-    user.send_password_reset_instructions if user.present?
+    user&.send_password_reset_instructions
 
     flash[:notice] = I18n.t("revise_auth.password_reset_sent")
     redirect_to login_path

--- a/app/controllers/revise_auth/password_resets_controller.rb
+++ b/app/controllers/revise_auth/password_resets_controller.rb
@@ -6,10 +6,8 @@ class ReviseAuth::PasswordResetsController < ReviseAuthController
   end
 
   def create
-    if (user = User.find_by(email: user_params[:email]))
-      token = user.generate_token_for(:password_reset)
-      ReviseAuth::Mailer.with(user: user, token: token).password_reset.deliver_later
-    end
+    user = User.find_by(email: user_params[:email])
+    user.send_password_reset_instructions if user.present?
 
     flash[:notice] = I18n.t("revise_auth.password_reset_sent")
     redirect_to login_path

--- a/lib/revise_auth/model.rb
+++ b/lib/revise_auth/model.rb
@@ -30,6 +30,12 @@ module ReviseAuth
       ReviseAuth::Mailer.with(user: self, token: token).confirm_email.deliver_later
     end
 
+    # Generates a password reset token and send email to the user
+    def send_password_reset_instructions
+      token = generate_token_for(:password_reset)
+      ReviseAuth::Mailer.with(user: self, token: token).password_reset.deliver_later
+    end
+
     def confirm_email_change
       update(confirmed_at: Time.current, email: unconfirmed_email)
     end


### PR DESCRIPTION
I was reading the code and found out an inconsistency. The confirmation instruction email was being sent by calling `ReviseAuth::Model#send_confirmation_instructions` but the password reset email was sent in the password resets controller. Think it's a nice refactor.