### PR TITLE
I18n: translate all strings and add i18n-tasks.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem "turbo-rails"
 gem "importmap-rails"
 gem "standard"
 gem "appraisal"
+gem "i18n-tasks"
+gem "highline", "~> 2.0"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 gem "debug", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,13 @@ GEM
     ast (2.4.2)
     base64 (0.1.1)
     bcrypt (3.1.19)
+    better_html (2.0.2)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.4)
     bindex (0.8.1)
     builder (3.2.4)
@@ -103,8 +110,20 @@ GEM
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    highline (2.1.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.13)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -137,6 +156,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.16.2-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-darwin)
@@ -181,6 +202,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.8)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.0.rc2)
       actionpack (= 7.1.0.rc2)
       activesupport (= 7.1.0.rc2)
@@ -216,6 +240,7 @@ GEM
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -223,6 +248,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.6-aarch64-linux)
     sqlite3 (1.6.6-arm64-darwin)
     sqlite3 (1.6.6-x86_64-darwin)
     sqlite3 (1.6.6-x86_64-linux)
@@ -239,6 +265,8 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.19.0)
     stringio (3.0.8)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
     timeout (0.4.0)
     turbo-rails (1.4.0)
@@ -260,6 +288,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-22
   x86_64-darwin-20
@@ -270,6 +299,8 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   debug (>= 1.0.0)
+  highline (~> 2.0)
+  i18n-tasks
   importmap-rails
   puma
   revise_auth!

--- a/app/controllers/revise_auth/email_controller.rb
+++ b/app/controllers/revise_auth/email_controller.rb
@@ -4,17 +4,17 @@ class ReviseAuth::EmailController < ReviseAuthController
   # GET /profile/email?confirmation_token=abcdef
   def show
     if User.find_by_token_for(:email_verification, params[:confirmation_token])&.confirm_email_change
-      flash[:notice] = I18n.t("revise_auth.email_confirmed")
+      flash[:notice] = t(".email_confirmed")
       redirect_to(user_signed_in? ? profile_path : root_path)
     else
-      redirect_to root_path, alert: I18n.t("revise_auth.email_confirm_failed")
+      redirect_to root_path, alert: t(".email_confirm_failed")
     end
   end
 
   def update
     if current_user.update(email_params)
       current_user.send_confirmation_instructions
-      flash[:notice] = I18n.t("revise_auth.confirmation_email_sent", email: current_user.unconfirmed_email)
+      flash[:notice] = t(".confirmation_email_sent", email: current_user.unconfirmed_email)
     end
 
     redirect_to profile_path

--- a/app/controllers/revise_auth/password_controller.rb
+++ b/app/controllers/revise_auth/password_controller.rb
@@ -3,9 +3,9 @@ class ReviseAuth::PasswordController < ReviseAuthController
 
   def update
     if current_user.update(password_params)
-      redirect_to profile_path, notice: I18n.t("revise_auth.password_changed")
+      redirect_to profile_path, notice: t(".password_changed")
     else
-      flash[:alert] = I18n.t("revise_auth.incorrect_password")
+      flash[:alert] = t(".incorrect_password")
       render "revise_auth/registrations/edit", status: :unprocessable_entity
     end
   end

--- a/app/controllers/revise_auth/password_resets_controller.rb
+++ b/app/controllers/revise_auth/password_resets_controller.rb
@@ -9,7 +9,7 @@ class ReviseAuth::PasswordResetsController < ReviseAuthController
     user = User.find_by(email: user_params[:email])
     user&.send_password_reset_instructions
 
-    flash[:notice] = I18n.t("revise_auth.password_reset_sent")
+    flash[:notice] = t(".password_reset_sent")
     redirect_to login_path
   end
 
@@ -18,7 +18,7 @@ class ReviseAuth::PasswordResetsController < ReviseAuthController
 
   def update
     if @user.update(password_params)
-      flash[:notice] = I18n.t("revise_auth.password_changed")
+      flash[:notice] = t("revise_auth.password.update.password_changed")
       redirect_to login_path
     else
       render :edit, status: :unprocessable_entity
@@ -32,7 +32,7 @@ class ReviseAuth::PasswordResetsController < ReviseAuthController
 
     return if @user.present?
 
-    flash[:alert] = I18n.t("revise_auth.password_link_invalid")
+    flash[:alert] = t(".invalid_password_link")
     redirect_to new_password_reset_path
   end
 

--- a/app/controllers/revise_auth/registrations_controller.rb
+++ b/app/controllers/revise_auth/registrations_controller.rb
@@ -20,7 +20,7 @@ class ReviseAuth::RegistrationsController < ReviseAuthController
 
   def update
     if current_user.update(profile_params)
-      redirect_to profile_path, notice: I18n.t("revise_auth.account_updated")
+      redirect_to profile_path, notice: t(".account_updated")
     else
       render :edit, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class ReviseAuth::RegistrationsController < ReviseAuthController
   def destroy
     current_user.destroy
     logout
-    redirect_to root_path, status: :see_other, alert: I18n.t("revise_auth.account_deleted")
+    redirect_to root_path, status: :see_other, alert: t(".account_deleted")
   end
 
   private

--- a/app/controllers/revise_auth/sessions_controller.rb
+++ b/app/controllers/revise_auth/sessions_controller.rb
@@ -7,7 +7,7 @@ class ReviseAuth::SessionsController < ReviseAuthController
       login(user)
       redirect_to resolve_after_login_path
     else
-      flash[:alert] = I18n.t("revise_auth.invalid_email_or_password")
+      flash[:alert] = t(".invalid_email_or_password")
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/views/revise_auth/mailer/confirm_email.html.erb
+++ b/app/views/revise_auth/mailer/confirm_email.html.erb
@@ -1,7 +1,7 @@
-<p>Welcome <%= @user.unconfirmed_email %>!</p>
+<p><%=t ".welcome", email: @user.unconfirmed_email %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%=t ".confirm_below" %></p>
 
-<p><%= link_to "Confirm my account", profile_email_url(confirmation_token: @token) %></p>
+<p><%= link_to t(".confirm"), profile_email_url(confirmation_token: @token) %></p>
 
-<p>This link will expire in 24 hours.</p>
+<p><%=t ".expiration_notice" %></p>

--- a/app/views/revise_auth/mailer/password_reset.html.erb
+++ b/app/views/revise_auth/mailer/password_reset.html.erb
@@ -1,6 +1,5 @@
-<p>We've received a password reset request for your login. If this was you just visit the
-  the link below to finish up. If it wasn't you, you can simply ignore this email.</p>
+<p><%=t ".reset_password_below" %></p>
 
-<p><%= link_to "Reset my password", edit_password_reset_url(token: @token) %></p>
+<p><%= link_to t(".reset_password"), edit_password_reset_url(token: @token) %></p>
 
-<p>This link will expire in 1 hour.</p>
+<p><%=t ".expiration_notice" %></p>

--- a/app/views/revise_auth/password_resets/edit.html.erb
+++ b/app/views/revise_auth/password_resets/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Reset Your Password</h1>
+<h1><%=t ".reset_password" %></h1>
 
 <%= form_with model: @user, url: sign_up_path do |form| %>
   <% if form.object.errors.any? %>
@@ -20,6 +20,6 @@
   </div>
 
   <div>
-    <%= form.button "Reset password" %>
+    <%= form.button t(".reset_password") %>
   </div>
 <% end %>

--- a/app/views/revise_auth/password_resets/new.html.erb
+++ b/app/views/revise_auth/password_resets/new.html.erb
@@ -1,4 +1,4 @@
-<h1>Send Password Reset Instructions</h1>
+<h1><%=t ".send_password_reset_instructions" %></h1>
 
 <%= form_with model: @user, url: password_resets_path do |form| %>
   <% if form.object.errors.any? %>
@@ -15,6 +15,6 @@
   </div>
 
   <div>
-    <%= form.button "Send Reset Instructions" %>
+    <%= form.button t(".send_password_reset_instructions") %>
   </div>
 <% end %>

--- a/app/views/revise_auth/registrations/edit.html.erb
+++ b/app/views/revise_auth/registrations/edit.html.erb
@@ -1,11 +1,11 @@
-<h1>Profile</h1>
+<h1><%=t ".profile" %></h1>
 
 <%= form_with model: current_user, url: profile_email_path do |form| %>
   <fieldset>
-    <legend>Change Email Address</legend>
+    <legend><%=t ".change_email_address" %></legend>
 
     <% if current_user.unconfirmed_email? %>
-      <p>Waiting for confirmation of <%= current_user.unconfirmed_email %></p>
+      <p><%=t ".waiting_confirmation", email: current_user.unconfirmed_email %></p>
     <% end %>
 
     <% if form.object.errors.any? %>
@@ -16,23 +16,23 @@
       </ul>
     <% end %>
 
-    <p>Your email address is: <%= current_user.email %></p>
-    <p>To change your email, we will send a confirmation email to your new address to complete the change.</p>
+    <p><%=t ".current_email_address", email: current_user.email %></p>
+    <p><%=t ".confirmation_instructions" %></p>
 
     <div>
-      <%= form.label :unconfirmed_email, "Email address" %>
+      <%= form.label :unconfirmed_email, t(".new_email") %>
       <%= form.email_field :unconfirmed_email, required: true %>
     </div>
 
     <div>
-      <%= form.button "Save Changes" %>
+      <%= form.button t(".save") %>
     </div>
   </fieldset>
 <% end %>
 
 <%= form_with model: current_user, url: profile_password_path do |form| %>
   <fieldset>
-    <legend>Change Password</legend>
+    <legend><%=t ".change_password" %></legend>
 
     <% if form.object.errors.any? %>
       <ul>
@@ -43,12 +43,12 @@
     <% end %>
 
     <div>
-      <%= form.label :password_challenge, "Current password" %>
+      <%= form.label :password_challenge %>
       <%= form.password_field :password_challenge, required: true %>
     </div>
 
     <div>
-      <%= form.label :password, "New password" %>
+      <%= form.label :password, t(".new_password") %>
       <%= form.password_field :password, required: true %>
     </div>
 
@@ -58,14 +58,14 @@
     </div>
 
     <div>
-      <%= form.button "Save Changes" %>
+      <%= form.button t(".save") %>
     </div>
   </fieldset>
 <% end %>
 
 <%= form_with url: profile_path, method: :delete do |form| %>
   <fieldset>
-    <legend>Delete my account</legend>
-    <%= form.button "Delete account", data: { turbo_confirm: "Are you sure?" } %>
+    <legend><%=t ".delete_account" %></legend>
+    <%= form.button t(".delete_account"), data: { turbo_confirm: t(".confirm") } %>
   </fieldset>
 <% end %>

--- a/app/views/revise_auth/registrations/new.html.erb
+++ b/app/views/revise_auth/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<h1>Sign Up</h1>
+<h1><%=t ".sign_up" %></h1>
 
 <%= form_with model: @user, url: sign_up_path do |form| %>
   <% if form.object.errors.any? %>
@@ -6,9 +6,9 @@
       <% form.object.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
-    </ul>
   <% end %>
 
+    </ul>
   <div>
     <%= form.label :email %>
     <%= form.email_field :email, required: true, autofocus: true %>
@@ -25,6 +25,6 @@
   </div>
 
   <div>
-    <%= form.button "Sign Up" %>
+    <%= form.button t(".sign_up") %>
   </div>
 <% end %>

--- a/app/views/revise_auth/sessions/new.html.erb
+++ b/app/views/revise_auth/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h1>Log in</h1>
+<h1><%=t ".log_in" %></h1>
 
 <%= form_with url: login_path do |form| %>
   <div>
@@ -12,10 +12,10 @@
   </div>
 
   <div>
-    <%= form.button "Login" %>
+    <%= form.button t(".log_in") %>
   </div>
 
   <div>
-    <%= link_to "Reset your password", new_password_reset_path %>
+    <%= link_to t(".reset_password"), new_password_reset_path %>
   </div>
 <% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,161 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `Find.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `Find.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Directories where method names which should not be part of a relative key resolution.
+  # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.
+  # Directories listed here will not consider the name of the method part of the resolved key
+  #
+  # relative_exclude_method_name_paths:
+  #  -
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+  ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+    - app/assets/builds
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  # <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+#   # deepl_host: "https://api.deepl.com"
+#   # deepl_version: "v2"
+#   # add additional options to the DeepL.translate call: https://www.deepl.com/docs-api/translate-text/translate-text/
+#   deepl_options:
+#     formality: prefer_less
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+ignore_missing:
+  - revise_auth.password_resets.set_user.invalid_password_link
+
+## Consider these keys used:
+# ignore_unused:
+# - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+ignore_unused:
+  - "activerecord.attributes.*"
+  - "revise_auth.sign_up_or_login"
+  - "revise_auth.password_resets.edit.invalid_password_link"
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,16 +1,64 @@
+---
 cs:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
   revise_auth:
-    account_deleted: "Váš účet byl smazán."
-    account_updated: "Účet byl úspěšně aktualizován."
-
-    invalid_email_or_password: "Neplatný e-mail nebo heslo."
-    sign_up_or_login: "Pro pokračování se zaregistruje nebo přihlaste"
-
-    password_changed: "Vaše heslo bylo úspěšně změněno."
-    incorrect_password: "Vaše aktuální heslo je nesprávné. Zkuste to prosím znovu."
-    password_link_invalid: "Odkaz pro obnovení hesla je neplatný."
-    password_reset_sent: "E-mail s pokyny pro obnovení hesla byl odeslán."
-
-    email_confirmed: "Vaše e-mailová adresa byla úspěšně potvrzena."
-    email_confirm_failed: "Vaši e-mailovou adresu nelze potvrdit."
-    confirmation_email_sent: "Potvrzující e-mail byl odeslán na adresu %{email}."
+    email:
+      show:
+        email_confirm_failed: Vaši e-mailovou adresu nelze potvrdit.
+        email_confirmed: Vaše e-mailová adresa byla úspěšně potvrzena.
+      update:
+        confirmation_email_sent: Potvrzující e-mail byl odeslán na adresu %{email}.
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: Vaše aktuální heslo je nesprávné. Zkuste to prosím znovu.
+        password_changed: Vaše heslo bylo úspěšně změněno.
+    password_resets:
+      create:
+        password_reset_sent: E-mail s pokyny pro obnovení hesla byl odeslán.
+      edit:
+        invalid_password_link: Odkaz pro obnovení hesla je neplatný.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: Váš účet byl smazán.
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: Účet byl úspěšně aktualizován.
+    sessions:
+      create:
+        invalid_email_or_password: Neplatný e-mail nebo heslo.
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: Pro pokračování se zaregistruje nebo přihlaste

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,16 +1,64 @@
+---
 de:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
   revise_auth:
-    account_deleted: "Dein Account wurde gelöscht."
-    account_updated: "Account wurde erfolgreich aktualisiert."
-
-    invalid_email_or_password: "Ungültige Email oder Passwort."
-    sign_up_or_login: "Registrieren oder anmelden um fortzufahren."
-
-    # Password changes
-    password_changed: "Dein Passwort wurde erfolgreich geändert."
-    incorrect_password: "Das Passwort ist ungültig. Bitte versuche es erneut."
-
-    # Email confirmations
-    email_confirmed: "Deine Email wurde erfogreich bestätigt."
-    email_confirm_failed: "Email Adresse kann nicht bestätigt werden."
-    confirmation_email_sent: "Eine Bestätigungsemail wurde versandt an %{email}."
+    email:
+      show:
+        email_confirm_failed: Email Adresse kann nicht bestätigt werden.
+        email_confirmed: Deine Email wurde erfogreich bestätigt.
+      update:
+        confirmation_email_sent: Eine Bestätigungsemail wurde versandt an %{email}.
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: Das Passwort ist ungültig. Bitte versuche es erneut.
+        password_changed: Dein Passwort wurde erfolgreich geändert.
+    password_resets:
+      create:
+        password_reset_sent: An email with password reset instructions has been sent if that account exists.
+      edit:
+        invalid_password_link: The provided password reset link is invalid.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: Dein Account wurde gelöscht.
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: Account wurde erfolgreich aktualisiert.
+    sessions:
+      create:
+        invalid_email_or_password: Ungültige Email oder Passwort.
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: Registrieren oder anmelden um fortzufahren.

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,16 +1,64 @@
+---
 el:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
   revise_auth:
-    account_deleted: "Ο λογαριασμός σας έχει διαγραφεί."
-    account_updated: "Ο λογαριασμός σας έχει ενημερωθεί επιτυχώς."
-
-    invalid_email_or_password: "Μη έγκυρο email ή κωδικός πρόσβασης."
-    sign_up_or_login: "Εγγραφείτε ή συνδεθείτε για να συνεχίσετε."
-
-    # Password changes
-    password_changed: "Ο κωδικός πρόσβασής σας άλλαξε με επιτυχία."
-    incorrect_password: "Ο τρέχων κωδικός πρόσβασής σας είναι λανθασμένος. Παρακαλώ δοκιμάστε ξανά."
-
-    # Email confirmations
-    email_confirmed: "Η διεύθυνση email σας επιβεβαιώθηκε επιτυχώς."
-    email_confirm_failed: "Δεν είναι δυνατή η επιβεβαίωση της διεύθυνσης email."
-    confirmation_email_sent: "Ένα email επιβεβαίωσης έχει σταλεί στο %{email}."
+    email:
+      show:
+        email_confirm_failed: Δεν είναι δυνατή η επιβεβαίωση της διεύθυνσης email.
+        email_confirmed: Η διεύθυνση email σας επιβεβαιώθηκε επιτυχώς.
+      update:
+        confirmation_email_sent: Ένα email επιβεβαίωσης έχει σταλεί στο %{email}.
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: Ο τρέχων κωδικός πρόσβασής σας είναι λανθασμένος. Παρακαλώ δοκιμάστε ξανά.
+        password_changed: Ο κωδικός πρόσβασής σας άλλαξε με επιτυχία.
+    password_resets:
+      create:
+        password_reset_sent: An email with password reset instructions has been sent if that account exists.
+      edit:
+        invalid_password_link: The provided password reset link is invalid.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: Ο λογαριασμός σας έχει διαγραφεί.
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: Ο λογαριασμός σας έχει ενημερωθεί επιτυχώς.
+    sessions:
+      create:
+        invalid_email_or_password: Μη έγκυρο email ή κωδικός πρόσβασης.
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: Εγγραφείτε ή συνδεθείτε για να συνεχίσετε.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,18 +1,64 @@
+---
 en:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
   revise_auth:
-    account_deleted: "Your account has been deleted."
-    account_updated: "Account updated successfully."
-
-    invalid_email_or_password: "Invalid email or password."
-    sign_up_or_login: "Sign up or log in to continue."
-
-    # Password changes
-    password_changed: "Your password has been changed successfully."
-    incorrect_password: "Your current password is incorrect. Please try again."
-    password_link_invalid: "The provided password reset link is invalid."
-    password_reset_sent: "An email with password reset instructions has been sent if that account exists."
-
-    # Email confirmations
-    email_confirmed: "Your email address has been successfully confirmed."
-    email_confirm_failed: "Unable to confirm email address."
-    confirmation_email_sent: "A confirmation email has been sent to %{email}."
+    email:
+      show:
+        email_confirm_failed: Unable to confirm email address.
+        email_confirmed: Your email address has been successfully confirmed.
+      update:
+        confirmation_email_sent: A confirmation email has been sent to %{email}.
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: Your current password is incorrect. Please try again.
+        password_changed: Your password has been changed successfully.
+    password_resets:
+      create:
+        password_reset_sent: An email with password reset instructions has been sent if that account exists.
+      edit:
+        invalid_password_link: The provided password reset link is invalid.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: Your account has been deleted.
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: Account updated successfully.
+    sessions:
+      create:
+        invalid_email_or_password: Invalid email or password.
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: Sign up or log in to continue.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,18 +1,64 @@
-en:
+---
+es:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Contraseña
+        password_challenge: Contraseña actual
+        password_confirmation: Confirmar contraseña
   revise_auth:
-    account_deleted: "Tu cuenta ha sido eliminada."
-    account_updated: "Cuenta actualizada exitosamente."
-
-    invalid_email_or_password: "Email o contraseña inválidas."
-    sign_up_or_login: "Registrate o inicia sesión para continuar."
-
-    # Password changes
-    password_changed: "Tu contraseña ha sido actualizada exitosamente."
-    incorrect_password: "Tu contraseña actual es incorrecta. Por favor intenta nuevamente."
-    password_link_invalid: "El enlace de reseteo de contraseña es inválido."
-    password_reset_sent: "Ha sido enviado un email de reseteo de contraseña si esa cuenta existe."
-
-    # Email confirmations
-    email_confirmed: "Tu dirección de email ha sido confirmada exitosamente."
-    email_confirm_failed: "No es posible confirmar la dirección de email."
-    confirmation_email_sent: "Un email de confirmación ha sido enviado a %{email}."
+    email:
+      show:
+        email_confirm_failed: No es posible confirmar la dirección de email.
+        email_confirmed: Tu dirección de email ha sido confirmada exitosamente.
+      update:
+        confirmation_email_sent: Un email de confirmación ha sido enviado a %{email}.
+    mailer:
+      confirm_email:
+        confirm: Confirmar mi cuenta
+        confirm_below: 'Podés confirmar el email de tu cuenta mediante el siguiente enlace:'
+        expiration_notice: Este enlace expirará en 24 horas.
+        welcome: Bienvenido %{email}!
+      password_reset:
+        expiration_notice: Este enlace expirará en 1 hora.
+        reset_password: Resetear mi contraseña
+        reset_password_below: Recibimos una solicitud de reseteo de contraseña para tu cuenta. Si fuiste vos, visitá el siguiente enlace para finalizar. Si no fuiste vos, podés ignorar este correo.
+    password:
+      update:
+        incorrect_password: Tu contraseña actual es incorrecta. Por favor intenta nuevamente.
+        password_changed: Tu contraseña ha sido actualizada exitosamente.
+    password_resets:
+      create:
+        password_reset_sent: Ha sido enviado un email de reseteo de contraseña si esa cuenta existe.
+      edit:
+        invalid_password_link: El enlace de reseteo de contraseña es inválido.
+        reset_password: Resetear contraseña
+      new:
+        send_password_reset_instructions: Enviar instrucciones para resetear la contraseña
+    registrations:
+      destroy:
+        account_deleted: Tu cuenta ha sido eliminada.
+      edit:
+        change_email_address: Cambiar dirección de correo
+        change_password: Cambiar contraseña
+        confirm: Estás seguro?
+        confirmation_instructions: Para cambiar tu dirección de email, enviaremos un email de confirmación a tu nueva dirección para completar el cambio.
+        current_email_address: 'Tu dirección de correo es: %{email}.'
+        delete_account: Eliminar mi cuenta
+        new_email: Nuevo email
+        new_password: Nueva contraseño
+        profile: Perfil
+        save: Guardar cambios
+        waiting_confirmation: Esperando confirmación de %{email}.
+      new:
+        sign_up: Registrate
+      update:
+        account_updated: Cuenta actualizada exitosamente.
+    sessions:
+      create:
+        invalid_email_or_password: Email o contraseña inválidas.
+      new:
+        log_in: Iniciar sesión
+        reset_password: Resetear contraseña
+    sign_up_or_login: Registrate o inicia sesión para continuar.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,16 +1,64 @@
+---
 fr:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
   revise_auth:
-    account_deleted: "Votre compte a été supprimé."
-    account_updated: "Votre compte a été mis à jour."
-
-    invalid_email_or_password: "Email ou mot de passe incorrect."
-    sign_up_or_login: "Vous devez être connecté ou vous enregistrer pour continuer."
-
-    # Password changes
-    password_changed: "Votre mot de passe a été mis à jour avec succès."
-    incorrect_password: "Mot de passe incorrect. Merci de réessayer"
-
-    # Email confirmations
-    email_confirmed: "Votre adresse email vient d'être confirmé."
-    email_confirm_failed: "Impossible de confirmer votre adresse email."
-    confirmation_email_sent: "Un email de confirmation vient d'être envoyé à %{email}."
+    email:
+      show:
+        email_confirm_failed: Impossible de confirmer votre adresse email.
+        email_confirmed: Votre adresse email vient d'être confirmé.
+      update:
+        confirmation_email_sent: Un email de confirmation vient d'être envoyé à %{email}.
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: Mot de passe incorrect. Merci de réessayer
+        password_changed: Votre mot de passe a été mis à jour avec succès.
+    password_resets:
+      create:
+        password_reset_sent: An email with password reset instructions has been sent if that account exists.
+      edit:
+        invalid_password_link: The provided password reset link is invalid.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: Votre compte a été supprimé.
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: Votre compte a été mis à jour.
+    sessions:
+      create:
+        invalid_email_or_password: Email ou mot de passe incorrect.
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: Vous devez être connecté ou vous enregistrer pour continuer.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,16 +1,64 @@
+---
 nl:
-    revise_auth:
-        account_deleted: "Uw account is verwijderd."
-        account_updated: "Account succesvol bijgewerkt."
-
-        invalid_email_of_password: "Ongeldige e-mail of wachtwoord."
-        sign_up_or_login: "Aanmelden of inloggen om door te gaan."
-
-        # Password changes
-        password_changed: "Uw wachtwoord is succesvol gewijzigd."
-        incorrect_password: "Uw huidige wachtwoord is onjuist. Probeer het opnieuw."
-
-        # E-mail confirmations
-        email_confirmed: "Uw e-mailadres is succesvol bevestigd."
-        email_confirm_failed: "E-mailadres bevestigen niet mogelijk."
-        confirmation_email_sent: "Er is een bevestigingsmail verzonden naar %{email}."
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
+  revise_auth:
+    email:
+      show:
+        email_confirm_failed: E-mailadres bevestigen niet mogelijk.
+        email_confirmed: Uw e-mailadres is succesvol bevestigd.
+      update:
+        confirmation_email_sent: Er is een bevestigingsmail verzonden naar %{email}.
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: Uw huidige wachtwoord is onjuist. Probeer het opnieuw.
+        password_changed: Uw wachtwoord is succesvol gewijzigd.
+    password_resets:
+      create:
+        password_reset_sent: An email with password reset instructions has been sent if that account exists.
+      edit:
+        invalid_password_link: The provided password reset link is invalid.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: Uw account is verwijderd.
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: Account succesvol bijgewerkt.
+    sessions:
+      create:
+        invalid_email_or_password: Ongeldige e-mail of wachtwoord.
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: Aanmelden of inloggen om door te gaan.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,16 +1,64 @@
+---
 pt:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
   revise_auth:
-    account_deleted: "A sua conta foi removida."
-    account_updated: "Conta atualizada com sucesso."
-
-    invalid_email_or_password: "Email ou password inválidos."
-    sign_up_or_login: "Registe-se ou clique em entrar para continuar."
-
-    # Password changes
-    password_changed: "A sua password foi alterada com sucesso."
-    incorrect_password: "A sua password atual está incorreta. Por favor tente de novo."
-
-    # Email confirmations
-    email_confirmed: "O seu endereço de email foi modificado com sucesso."
-    email_confirm_failed: "Não foi possível confirmar o endereço de email."
-    confirmation_email_sent: "Um email de confirmação foi enviado para %{email}."
+    email:
+      show:
+        email_confirm_failed: Não foi possível confirmar o endereço de email.
+        email_confirmed: O seu endereço de email foi modificado com sucesso.
+      update:
+        confirmation_email_sent: Um email de confirmação foi enviado para %{email}.
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: A sua password atual está incorreta. Por favor tente de novo.
+        password_changed: A sua password foi alterada com sucesso.
+    password_resets:
+      create:
+        password_reset_sent: An email with password reset instructions has been sent if that account exists.
+      edit:
+        invalid_password_link: The provided password reset link is invalid.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: A sua conta foi removida.
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: Conta atualizada com sucesso.
+    sessions:
+      create:
+        invalid_email_or_password: Email ou password inválidos.
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: Registe-se ou clique em entrar para continuar.

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,16 +1,64 @@
+---
 tr:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
   revise_auth:
-    account_deleted: "Hesabınız silindi."
-    account_updated: "Hesap başarıyla güncellendi."
-
-    invalid_email_or_password: "Geçersiz e-posta veya şifre."
-    sign_up_or_login: "Devam etmek için kaydol veya giriş yap."
-
-    # Password changes
-    password_changed: "Şifreniz başarıyla güncellendi."
-    incorrect_password: "Şu anki şifreniz yanlış. Lütfen tekrar deneyiniz."
-
-    # Email confirmations
-    email_confirmed: "E-posta adresiniz başarıyla onaylandı."
-    email_confirm_failed: "E-posta adresi doğrulanamıyor."
-    confirmation_email_sent: "%{email} adresine onay e-postası gönderildi."
+    email:
+      show:
+        email_confirm_failed: E-posta adresi doğrulanamıyor.
+        email_confirmed: E-posta adresiniz başarıyla onaylandı.
+      update:
+        confirmation_email_sent: "%{email} adresine onay e-postası gönderildi."
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: Şu anki şifreniz yanlış. Lütfen tekrar deneyiniz.
+        password_changed: Şifreniz başarıyla güncellendi.
+    password_resets:
+      create:
+        password_reset_sent: An email with password reset instructions has been sent if that account exists.
+      edit:
+        invalid_password_link: The provided password reset link is invalid.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: Hesabınız silindi.
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: Hesap başarıyla güncellendi.
+    sessions:
+      create:
+        invalid_email_or_password: Geçersiz e-posta veya şifre.
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: Devam etmek için kaydol veya giriş yap.

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,16 +1,64 @@
+---
 zh-TW:
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        password_challenge: Current password
+        password_confirmation: Password confirmation
   revise_auth:
-    account_deleted: "您的帳號已經被刪除"
-    account_updated: "帳號更新成功"
-
-    invalid_email_or_password: "錯誤的信箱或是密碼"
-    sign_up_or_login: "需要註冊或是登入才能進行"
-
-    # Password changes
-    password_changed: "您的密碼已經成功地更新"
-    incorrect_password: "您現在輸入的密碼不正確, 請重新嘗試"
-
-    # Email confirmations
-    email_confirmed: "您的電子信箱已經成功地通過驗證"
-    email_confirm_failed: "無法驗證您的電子信箱"
-    confirmation_email_sent: "電子信箱驗證信已寄往 %{email}"
+    email:
+      show:
+        email_confirm_failed: 無法驗證您的電子信箱
+        email_confirmed: 您的電子信箱已經成功地通過驗證
+      update:
+        confirmation_email_sent: 電子信箱驗證信已寄往 %{email}
+    mailer:
+      confirm_email:
+        confirm: Confirm my account
+        confirm_below: 'You can confirm your account email through the link below:'
+        expiration_notice: This link will expire in 24 hours.
+        welcome: Welcome %{email}!
+      password_reset:
+        expiration_notice: This link will expire in 1 hour.
+        reset_password: Reset my password
+        reset_password_below: We've received a password reset request for your login. If this was you just visit the link below to finish up. If it wasn't you, you can simply ignore this email.
+    password:
+      update:
+        incorrect_password: 您現在輸入的密碼不正確, 請重新嘗試
+        password_changed: 您的密碼已經成功地更新
+    password_resets:
+      create:
+        password_reset_sent: An email with password reset instructions has been sent if that account exists.
+      edit:
+        invalid_password_link: The provided password reset link is invalid.
+        reset_password: Reset password
+      new:
+        send_password_reset_instructions: Send Password Reset Instructions
+    registrations:
+      destroy:
+        account_deleted: 您的帳號已經被刪除
+      edit:
+        change_email_address: Change Email Address
+        change_password: Change Password
+        confirm: Are you sure?
+        confirmation_instructions: To change your email, we will send a confirmation email to your new address to complete the change.
+        current_email_address: 'Your email address is: %{email}.'
+        delete_account: Delete my account
+        new_email: New Email
+        new_password: New password
+        profile: Profile
+        save: Save Changes
+        waiting_confirmation: Waiting for confirmation of %{email}.
+      new:
+        sign_up: Sign up
+      update:
+        account_updated: 帳號更新成功
+    sessions:
+      create:
+        invalid_email_or_password: 錯誤的信箱或是密碼
+      new:
+        log_in: Log in
+        reset_password: Reset your password
+    sign_up_or_login: 需要註冊或是登入才能進行

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -10,6 +10,8 @@ gem "turbo-rails"
 gem "importmap-rails"
 gem "standard"
 gem "appraisal"
+gem "i18n-tasks"
+gem "highline", "~> 2.0"
 gem "debug", ">= 1.0.0"
 gem "rails", "~> 7.1.0.beta1"
 

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -88,6 +88,13 @@ GEM
     ast (2.4.2)
     base64 (0.1.1)
     bcrypt (3.1.19)
+    better_html (2.0.2)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.4)
     bindex (0.8.1)
     builder (3.2.4)
@@ -103,8 +110,20 @@ GEM
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    highline (2.1.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.13)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -137,6 +156,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-darwin)
@@ -181,6 +202,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.8)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.0.rc2)
       actionpack (= 7.1.0.rc2)
       activesupport (= 7.1.0.rc2)
@@ -216,6 +240,7 @@ GEM
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -223,6 +248,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.6-aarch64-linux)
     sqlite3 (1.6.6-arm64-darwin)
     sqlite3 (1.6.6-x86_64-darwin)
     sqlite3 (1.6.6-x86_64-linux)
@@ -239,6 +265,8 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.19.0)
     stringio (3.0.8)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
     timeout (0.4.0)
     turbo-rails (1.4.0)
@@ -260,6 +288,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-22
   x86_64-darwin-20
@@ -269,6 +298,8 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   debug (>= 1.0.0)
+  highline (~> 2.0)
+  i18n-tasks
   importmap-rails
   puma
   rails (~> 7.1.0.beta1)

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -10,6 +10,8 @@ gem "turbo-rails"
 gem "importmap-rails"
 gem "standard"
 gem "appraisal"
+gem "i18n-tasks"
+gem "highline", "~> 2.0"
 gem "debug", ">= 1.0.0"
 gem "rails", git: "https://github.com/rails/rails.git"
 

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -115,6 +115,13 @@ GEM
     ast (2.4.2)
     base64 (0.1.1)
     bcrypt (3.1.19)
+    better_html (2.0.2)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.4)
     bindex (0.8.1)
     builder (3.2.4)
@@ -130,8 +137,20 @@ GEM
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    highline (2.1.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.13)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -164,6 +183,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-darwin)
@@ -194,6 +215,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.8)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     rainbow (3.1.1)
     rake (13.0.6)
     rdoc (6.5.0)
@@ -221,6 +245,7 @@ GEM
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -228,6 +253,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.6-aarch64-linux)
     sqlite3 (1.6.6-arm64-darwin)
     sqlite3 (1.6.6-x86_64-darwin)
     sqlite3 (1.6.6-x86_64-linux)
@@ -244,6 +270,8 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.19.0)
     stringio (3.0.8)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
     timeout (0.4.0)
     turbo-rails (1.4.0)
@@ -265,6 +293,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-22
   x86_64-darwin-20
@@ -274,6 +303,8 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   debug (>= 1.0.0)
+  highline (~> 2.0)
+  i18n-tasks
   importmap-rails
   puma
   rails!

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "i18n/tasks"
+
+class I18nTest < ActiveSupport::TestCase
+  def setup
+    @i18n = I18n::Tasks::BaseTask.new
+  end
+
+  def test_no_missing_keys
+    missing_keys = @i18n.missing_keys
+    assert_empty missing_keys,
+      "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+
+  def test_no_unused_keys
+    unused_keys = @i18n.unused_keys
+    assert_empty unused_keys,
+      "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+  end
+
+  def test_files_are_normalized
+    non_normalized = @i18n.non_normalized_paths
+    error_message = "The following files need to be normalized:\n" \
+                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
+                    "Please run `i18n-tasks normalize' to fix"
+    assert_empty non_normalized, error_message
+  end
+
+  def test_no_inconsistent_interpolations
+    inconsistent_interpolations = @i18n.inconsistent_interpolations
+    error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
+                    "Please run `i18n-tasks check-consistent-interpolations' to show them"
+    assert_empty inconsistent_interpolations, error_message
+  end
+end


### PR DESCRIPTION
Translated all strings (all locale files but `en` and `es` are incomplete, but I can give google translate a try 😛 ). 
Also added `i18n-tasks` to normalize the locale files but more importantly it adds tests that fail if there are missing or unused i18n keys.