### PR TITLE
Customize registration params

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Note: This should be set in all environments.
 
 ## Customizing
 
+### Views
+
 To customize views, you can run:
 
 ```bash
@@ -98,6 +100,24 @@ $ rails g revise_auth:views
 ```
 
 This will copy the views into `app/views/revise_auth` in your application.
+
+### Controllers
+
+If your User model has additional fields and you want to customize your views to allow filling them up during sign up or editing your profile, you need to permit those additional fields.
+
+To do this, define `sign_up_params` and/or `profile_params` in your `ApplicationController` to allow those additional attributes during sign up or profile edit, respectively. You can also override `ReviseAuthController` and define it there.
+
+```ruby
+class ApplicationController < ActionController::Base
+  def sign_up_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+  end
+
+  def profile_params
+    params.require(:user).permit(:first_name, :last_name)
+  end
+end
+```
 
 ### After Login Path
 

--- a/app/controllers/revise_auth/registrations_controller.rb
+++ b/app/controllers/revise_auth/registrations_controller.rb
@@ -6,7 +6,7 @@ class ReviseAuth::RegistrationsController < ReviseAuthController
   end
 
   def create
-    @user = User.new(sign_up_params)
+    @user = User.new(resolve_sign_up_params)
     if @user.save
       login(@user)
       redirect_to root_path
@@ -19,7 +19,7 @@ class ReviseAuth::RegistrationsController < ReviseAuthController
   end
 
   def update
-    if current_user.update(profile_params)
+    if current_user.update(resolve_profile_params)
       redirect_to profile_path, notice: I18n.t("revise_auth.account_updated")
     else
       render :edit, status: :unprocessable_entity
@@ -34,11 +34,11 @@ class ReviseAuth::RegistrationsController < ReviseAuthController
 
   private
 
-  def sign_up_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  def resolve_sign_up_params
+    try(:sign_up_params) || params.require(:user).permit(:email, :password, :password_confirmation)
   end
 
-  def profile_params
-    params.require(:user).permit(:name)
+  def resolve_profile_params
+    try(:profile_params) || params.require(:user)
   end
 end

--- a/test/controllers/revise_auth/registrations_controller_test.rb
+++ b/test/controllers/revise_auth/registrations_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class ReviseAuth::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users :bob
+  end
+
+  test "users should be able to sign up" do
+    assert_changes -> { User.count } do
+      post sign_up_path, params: {user: {email: "new-email@example.com", password: "password1234", password_confirmation: "password1234"}}
+    end
+  end
+
+  test "shouldn't set first and last name if sign_up_params is not defined" do
+    assert_changes -> { User.count } do
+      post sign_up_path, params: {user: {email: "new-email@example.com", password: "password1234", password_confirmation: "password1234"}}
+    end
+    user = User.last
+    assert_nil user.first_name
+    assert_nil user.last_name
+  end
+
+  test "should set first and last name if sign_up_params is defined" do
+    ::ApplicationController.define_method :sign_up_params do
+      params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+    end
+    assert_changes -> { User.count } do
+      post sign_up_path, params: {user: {email: "new-email@example.com", password: "password1234", password_confirmation: "password1234", first_name: "John", last_name: "Lennon"}}
+    end
+    user = User.last
+    assert_equal "John", user.first_name
+    assert_equal "Lennon", user.last_name
+    ::ApplicationController.undef_method :sign_up_params
+  end
+
+  test "users should be able to update their account" do
+    patch profile_path
+    assert_response :redirect
+  end
+
+  test "should set first and last name if profile_params is defined" do
+    ::ApplicationController.define_method :profile_params do
+      params.require(:user).permit(:first_name, :last_name)
+    end
+    login @user
+    patch profile_path, params: {user: {first_name: "John", last_name: "Lennon"}}
+    assert_equal "John", @user.reload.first_name
+    assert_equal "Lennon", @user.last_name
+    ::ApplicationController.undef_method :profile_params
+  end
+
+  test "users should be able to delete their account" do
+    login @user
+    assert_changes -> { User.count } do
+      delete profile_path
+    end
+  end
+end


### PR DESCRIPTION
The `revise_auth:model` generator allows you to add additional attributes to the User model. However, if you want to change your sign up form or profile form, those additional attributes are not permitted. To allow this, we need to allow customizing the registration params (`sign_up_params` and `profile_params`). I followed the same idea as the `after_login_path`. Also added some tests as the registration controller had none.