### PR TITLE
Add configurable form params

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ $ rails g revise_auth:views
 
 This will copy the views into `app/views/revise_auth` in your application.
 
+### Form Permitted Params
+
+To customize the form parameters, you can add/remove params in `config/initializers/revise_auth.rb`
+
+```ruby
+ReviseAuth.configure do |config|
+  config.sign_up_params += [:time_zone]
+  config.update_params += [:time_zone]
+end
+```
+
 ### After Login Path
 
 After a user logs in they will be redirected to the stashed location or the root path, by default. When a GET request hits `authenticate_user!`, it will stash the request path in the session and redirect back after login.

--- a/app/controllers/revise_auth/registrations_controller.rb
+++ b/app/controllers/revise_auth/registrations_controller.rb
@@ -35,10 +35,10 @@ class ReviseAuth::RegistrationsController < ReviseAuthController
   private
 
   def sign_up_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(ReviseAuth.sign_up_params)
   end
 
   def profile_params
-    params.require(:user).permit(:name)
+    params.require(:user).permit(ReviseAuth.update_params)
   end
 end

--- a/lib/generators/revise_auth/model_generator.rb
+++ b/lib/generators/revise_auth/model_generator.rb
@@ -25,6 +25,10 @@ module ReviseAuth
         inject_into_class model_path, "User", "  include ReviseAuth::Model\n"
       end
 
+      def copy_initializer
+        template "initializer.rb", "config/initializers/revise_auth.rb"
+      end
+
       def done
         readme "README" if behavior == :invoke
       end

--- a/lib/generators/revise_auth/templates/README
+++ b/lib/generators/revise_auth/templates/README
@@ -2,3 +2,6 @@
 
 Next step:
   Run "rails db:migrate"
+
+To customize views:
+  Run "rails generate revise_auth:views"

--- a/lib/generators/revise_auth/templates/initializer.rb
+++ b/lib/generators/revise_auth/templates/initializer.rb
@@ -1,0 +1,5 @@
+ReviseAuth.configure do |config|
+  # Customize the params for registration and update profile.
+  # config.sign_up_params += [:time_zone]
+  # config.update_params += [:time_zone]
+end

--- a/lib/revise_auth.rb
+++ b/lib/revise_auth.rb
@@ -7,4 +7,9 @@ module ReviseAuth
   autoload :Current, "revise_auth/current"
   autoload :Model, "revise_auth/model"
   autoload :RouteConstraint, "revise_auth/route_constraint"
+
+  include ActiveSupport::Configurable
+
+  config_accessor :sign_up_params, default: [:name, :email, :password, :password_confirmation]
+  config_accessor :update_params, default: [:name]
 end


### PR DESCRIPTION
This is a different take on #59 which introduces configurable form permitted params.

This makes it a simple configuration option in an initializer and also lays groundwork for other configuration options.

Closes #59 