### PR TITLE
Add configurable password length validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ authenticated do
 end
 ```
 
+### Password Length
+
+The minimum acceptable password length for validation defaults to 12 characters but this can be configured in either `config/initializers/revise_auth.rb` or your environment configuration:
+```ruby
+ReviseAuth.configure do |config|
+  config.minimum_password_length = 42
+end
+```
+
 ## Contributing
 
 If you have an issue you'd like to submit, please do so using the issue tracker in GitHub. In order for us to help you in the best way possible, please be as detailed as you can.

--- a/lib/revise_auth.rb
+++ b/lib/revise_auth.rb
@@ -12,4 +12,5 @@ module ReviseAuth
 
   config_accessor :sign_up_params, default: [:email, :password, :password_confirmation]
   config_accessor :update_params, default: []
+  config_accessor :minimum_password_length, default: 12
 end

--- a/lib/revise_auth/model.rb
+++ b/lib/revise_auth/model.rb
@@ -21,7 +21,7 @@ module ReviseAuth
 
       validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, presence: true, uniqueness: true
       validates :unconfirmed_email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_blank: true
-      validates_length_of :password, minimum: 12, allow_nil: true
+      validates_length_of :password, minimum: ReviseAuth.minimum_password_length, allow_nil: true
     end
 
     # Generates a confirmation token and send email to the user

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -19,6 +19,35 @@ class UserTest < ActiveSupport::TestCase
     refute_empty user.errors.where(:password, :blank)
   end
 
+  test "password meets minimum length" do
+    valid_user = User.new(email: "test@example.org")
+
+    # Default minimum password length is 12 characters
+    valid_user.password = "a" * 14
+    valid_user.valid?
+    assert_empty valid_user.errors.where(:password, :too_short)
+
+    # Change minimum password length
+    ReviseAuth.minimum_password_length = 16
+
+    # Remove User object and reload file to capture new configuration
+    Object.send(:remove_const, :User)
+    load Rails.root.join "app/models/user.rb"
+
+    # Recreate the user with the new minimum length validation
+    invalid_user = User.new(email: "test@example.org")
+
+    # Minimum password length is now 16 characters (set above in this test)
+    invalid_user.password = "a" * 14
+    invalid_user.valid?
+    refute_empty invalid_user.errors.where(:password, :too_short)
+
+    # Clean up/revert changes to config for additional tests
+    ReviseAuth.minimum_password_length = 12
+    Object.send(:remove_const, :User)
+    load Rails.root.join "app/models/user.rb"
+  end
+
   test "email is downcased" do
     user = User.new(email: "TEST@example.org")
     user.valid?


### PR DESCRIPTION
- Replaces the hardcoded password length minimum validator (12 characters) with a configuration variable
- Adds test to check validation with multiple configurations
- Adds documentation to README.md