### PR TITLE
refactor links

### DIFF
--- a/app/views/revise_auth/password_resets/new.html.erb
+++ b/app/views/revise_auth/password_resets/new.html.erb
@@ -18,3 +18,5 @@
     <%= form.button t(".send_password_reset_instructions") %>
   </div>
 <% end %>
+
+<%= render "revise_auth/shared/links" %>

--- a/app/views/revise_auth/registrations/new.html.erb
+++ b/app/views/revise_auth/registrations/new.html.erb
@@ -28,3 +28,5 @@
     <%= form.button t(".sign_up") %>
   </div>
 <% end %>
+
+<%= render "revise_auth/shared/links" %>

--- a/app/views/revise_auth/sessions/new.html.erb
+++ b/app/views/revise_auth/sessions/new.html.erb
@@ -14,8 +14,6 @@
   <div>
     <%= form.button t(".log_in") %>
   </div>
-
-  <div>
-    <%= link_to t(".reset_password"), new_password_reset_path %>
-  </div>
 <% end %>
+
+<%= render "revise_auth/shared/links" %>

--- a/app/views/revise_auth/shared/_links.html.erb
+++ b/app/views/revise_auth/shared/_links.html.erb
@@ -1,0 +1,15 @@
+<% if controller_name == "sessions" %>
+  <div>
+    <%= link_to t(".reset_password"), new_password_reset_path %>
+  </div>
+<% else %>
+  <div>
+    <%= link_to t(".log_in"), login_path %>
+  </div>
+<% end %>
+
+<% if controller_name != "registrations" %>
+  <div>
+    <%= link_to t(".sign_up"), sign_up_path %>
+  </div>
+<% end %>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -60,5 +60,9 @@ cs:
         invalid_email_or_password: Neplatný e-mail nebo heslo.
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: Pro pokračování se zaregistruje nebo přihlaste

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -60,5 +60,9 @@ de:
         invalid_email_or_password: Ungültige Email oder Passwort.
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: Registrieren oder anmelden um fortzufahren.

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -60,5 +60,9 @@ el:
         invalid_email_or_password: Μη έγκυρο email ή κωδικός πρόσβασης.
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: Εγγραφείτε ή συνδεθείτε για να συνεχίσετε.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,5 +60,9 @@ en:
         invalid_email_or_password: Invalid email or password.
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: Sign up or log in to continue.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -60,5 +60,9 @@ es:
         invalid_email_or_password: Email o contraseña inválidas.
       new:
         log_in: Iniciar sesión
+    shared:
+      links:
+        log_in: Iniciar sesión
         reset_password: Resetear contraseña
+        sign_up: Registrate
     sign_up_or_login: Registrate o inicia sesión para continuar.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -60,5 +60,9 @@ fr:
         invalid_email_or_password: Email ou mot de passe incorrect.
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: Vous devez être connecté ou vous enregistrer pour continuer.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -60,5 +60,9 @@ nl:
         invalid_email_or_password: Ongeldige e-mail of wachtwoord.
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: Aanmelden of inloggen om door te gaan.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -60,5 +60,9 @@ pt:
         invalid_email_or_password: Email ou password inválidos.
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: Registe-se ou clique em entrar para continuar.

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -60,5 +60,9 @@ tr:
         invalid_email_or_password: Geçersiz e-posta veya şifre.
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: Devam etmek için kaydol veya giriş yap.

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -60,5 +60,9 @@ zh-TW:
         invalid_email_or_password: 錯誤的信箱或是密碼
       new:
         log_in: Log in
+    shared:
+      links:
+        log_in: Log in
         reset_password: Reset your password
+        sign_up: Sign up
     sign_up_or_login: 需要註冊或是登入才能進行


### PR DESCRIPTION
the only way to go from login to new registration was by typing it in the url. I wanted to that link but noticed that there was no way to go back either, same thing for reset password.

this PR adds a link partial which is rendered in the login, new registration and reset password pages.