### PR TITLE
Add new session rate limit for Rails 7.2+

### DIFF
--- a/app/controllers/revise_auth/sessions_controller.rb
+++ b/app/controllers/revise_auth/sessions_controller.rb
@@ -1,4 +1,6 @@
 class ReviseAuth::SessionsController < ReviseAuthController
+  rate_limit ReviseAuth.rate_limit if respond_to?(:rate_limit) && ReviseAuth.rate_limit.present?
+
   def new
   end
 

--- a/app/controllers/revise_auth/sessions_controller.rb
+++ b/app/controllers/revise_auth/sessions_controller.rb
@@ -1,5 +1,5 @@
 class ReviseAuth::SessionsController < ReviseAuthController
-  rate_limit **ReviseAuth.login_rate_limit if respond_to?(:rate_limit) && ReviseAuth.login_rate_limit.present?
+  rate_limit(**ReviseAuth.login_rate_limit) if respond_to?(:rate_limit) && ReviseAuth.login_rate_limit.present?
 
   def new
   end

--- a/app/controllers/revise_auth/sessions_controller.rb
+++ b/app/controllers/revise_auth/sessions_controller.rb
@@ -1,5 +1,5 @@
 class ReviseAuth::SessionsController < ReviseAuthController
-  rate_limit ReviseAuth.rate_limit if respond_to?(:rate_limit) && ReviseAuth.rate_limit.present?
+  rate_limit **ReviseAuth.login_rate_limit if respond_to?(:rate_limit) && ReviseAuth.login_rate_limit.present?
 
   def new
   end

--- a/lib/revise_auth.rb
+++ b/lib/revise_auth.rb
@@ -17,5 +17,5 @@ module ReviseAuth
   config_accessor :sign_up_params, default: [:email, :password, :password_confirmation]
   config_accessor :update_params, default: []
   config_accessor :minimum_password_length, default: 12
-  config_accessor :rate_limit, default: {to: 5, within: 1.minute, only: :create}
+  config_accessor :login_rate_limit, default: {to: 10, within: 3.minutes, only: :create}
 end

--- a/lib/revise_auth.rb
+++ b/lib/revise_auth.rb
@@ -17,4 +17,5 @@ module ReviseAuth
   config_accessor :sign_up_params, default: [:email, :password, :password_confirmation]
   config_accessor :update_params, default: []
   config_accessor :minimum_password_length, default: 12
+  config_accessor :rate_limit, default: {to: 5, within: 1.minute, only: :create}
 end


### PR DESCRIPTION
Rails 7.2 introduces a new `rate_limit` feature for controllers backed by cache or Kredis.

We can use this to provide a default rate limit for login with Revise Auth. 

This will be ignored for Rails 7.1.