### PR TITLE
Document flash message setup in Usage section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ revise_auth
 
 You will want to define a root path. After login (see below), the user will be redirected to the root path.
 
+### Views
+
+ReviseAuth uses the flash to display notices and alerts, so make sure flash messages are rendered by your application:
+
+```erb
+<%# views/layouts/application.html.erb %>
+
+<%= tag.div notice if notice %>
+<%= tag.div alert if alert %>
+```
+
 ### Filters and Helpers
 
 To protect your actions from unauthenticated users, you can use the `authenticate_user!` filter:


### PR DESCRIPTION
After adding ReviseAuth to a new Rails app, I noticed no flash messages were being displayed since I had not yet added them to my layout.

I've added this step to the README in case it is helpful to others.

Thanks!