### PR TITLE
Updates for ActiveSupport::Configurable deprecation

### DIFF
--- a/lib/revise_auth.rb
+++ b/lib/revise_auth.rb
@@ -1,10 +1,11 @@
+require "active_support"
+require "active_support/core_ext"
+
 require "revise_auth/version"
 require "revise_auth/engine"
 require "revise_auth/routes"
 
 module ReviseAuth
-  include ActiveSupport::Configurable
-
   autoload :Authentication, "revise_auth/authentication"
   autoload :Current, "revise_auth/current"
   autoload :Model, "revise_auth/model"
@@ -14,8 +15,12 @@ module ReviseAuth
     autoload :Helpers, "revise_auth/test/helpers"
   end
 
-  config_accessor :sign_up_params, default: [:email, :password, :password_confirmation]
-  config_accessor :update_params, default: []
-  config_accessor :minimum_password_length, default: 12
-  config_accessor :login_rate_limit, default: {to: 10, within: 3.minutes, only: :create}
+  def self.configure
+    yield self
+  end
+
+  mattr_accessor :sign_up_params, default: [:email, :password, :password_confirmation]
+  mattr_accessor :update_params, default: []
+  mattr_accessor :minimum_password_length, default: 12
+  mattr_accessor :login_rate_limit, default: {to: 10, within: 3.minutes, only: :create}
 end


### PR DESCRIPTION
This should address #121 

- Use `mattr_accessor` instead of `config_accessor`
- Define a `configure` that yields self